### PR TITLE
default to 'html' for unknown file extensions

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -50,7 +50,9 @@ function preprocess(src,context,type) {
   src = src.toString();
   context = context || process.env;
 
-  type = type || 'html';
+  if (typeof delim[type] === 'undefined'){
+    type = 'html';
+  }
 
   var rv = src;
 


### PR DESCRIPTION
before this change the code passed unknown 'type' as is and then crashed in 'getRegex'
