### PR TITLE
Detect if included file exists

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -58,9 +58,12 @@ function preprocess(src,context,type) {
 
   rv = rv.replace(getRegex(type,'include'),function(match,file,include){
     file = (file || '').trim();
-    var includedSource = fs.readFileSync(path.join(context.srcDir,file));
-    includedSource = preprocess(includedSource, context, type);
-    return includedSource || match + ' not found';
+    var filePath = path.join(context.srcDir,file);
+    if (!fs.existsSync(filePath)) {
+        return file + ' not found';
+    }
+    var includedSource = fs.readFileSync(filePath);
+    return preprocess(includedSource, context, type);
   });
 
   rv = rv.replace(getRegex(type,'exclude'),function(match,test,include){


### PR DESCRIPTION
The current implementation of the `include` replacement doesn't check if the file actually exists or not when returning the "`file` not found" message, it simply checks if the file content is truthy or not.

This change uses `fs.existsSync()` to check if the file exists - returning "`file` not found" if it isn't - before processing and injecting the contents (empty or not) into the file.
