### PR TITLE
Added possibility to use nested context objects

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -48,6 +48,7 @@ function getExtension(filename) {
 function preprocess(src,context,type) {
   src = src.toString();
   context = context || process.env;
+  context = getFlattedContext(context);
 
   if (typeof delim[type] === 'undefined'){
     type = 'html';
@@ -126,4 +127,22 @@ function getTestTemplate(test) {
 function testPasses(test,context) {
   var testFn = getTestTemplate(test);
   return testFn(context);
+}
+
+function getFlattedContext(context) {
+  var toReturn = {};
+  for (var i in context) {
+    if (!context.hasOwnProperty(i)) continue;
+
+    toReturn[i] = context[i];
+    if ((typeof context[i]) === 'object') {
+      var flatObject = getFlattedContext(context[i]);
+      for (var x in flatObject) {
+        if (!flatObject.hasOwnProperty(x)) continue;
+
+        toReturn[i + '.' + x] = flatObject[x];
+      }
+    }
+  }
+  return toReturn;
 }

--- a/test/preprocess_test.js
+++ b/test/preprocess_test.js
@@ -419,5 +419,29 @@ exports['preprocess'] = {
     var actual = fs.readFileSync('test/tmp/processFileSyncTest.dest.html').toString()
     test.equal(actual, expected, 'Should process a file to disk');
     test.done();
+  },
+  'multilevelContext': function(test) {
+    test.expect(3);
+
+    var input,expected,settings;
+    var context = {'FOO' :{'BAR':'test'}};
+
+    input = "// @echo FOO.BAR";
+    expected = "test";
+    test.equal(pp.preprocess(input, context, 'js'), expected, 'Should echo multi-level context');
+
+    input = "// @echo FOO";
+    expected = "[object Object]";
+    test.equal(pp.preprocess(input, context, 'js'), expected, 'Should maintain backwards compatibility');
+
+    input = "a\n" +
+      "// @if FOO.BAR=='test' \n" +
+      "b\n" +
+      "// @endif \n" +
+      "c";
+    expected = "a\nb\nc";
+    test.equal(pp.preprocess(input, context, 'js'), expected, 'Should compare multi-level context');
+
+    test.done();
   }
 };


### PR DESCRIPTION
I needed this type of functionality e.g. [here](https://github.com/jojanaho/piechopper/blob/master/server/mgmt/install.sh), and ended up implementing it into my own [Gruntfile](https://github.com/jojanaho/piechopper/blob/master/Gruntfile.coffee#L7). Might be worthwhile addition into the library?

Shouldn't break the compatibility, except in really rare cases where someone has used '.' in their context variables, and used it only with @echo (since with @if it would break due to usage of `with`).

All tests pass, new ones included.
