### PR TITLE
Add Peg.js extensions to regex rules list

### DIFF
--- a/lib/regexrules.js
+++ b/lib/regexrules.js
@@ -77,6 +77,8 @@ module.exports.sass       = module.exports.js;
 module.exports.scss       = module.exports.js;
 module.exports.css        = module.exports.js;
 module.exports.php        = module.exports.js;
+module.exports.peg        = module.exports.js;
+module.exports.pegjs      = module.exports.js;
 
 module.exports.coffee     = module.exports.coffee;
 module.exports.bash       = module.exports.coffee;


### PR DESCRIPTION
Peg.JS needs some loving too.

Supports single/multi-line comments, just as JavaScript.

Long rules or token lists are a perfect use-case for Preprocess.
