### PR TITLE
Add stylus to extensions that use js regex

### DIFF
--- a/lib/regexrules.js
+++ b/lib/regexrules.js
@@ -89,6 +89,7 @@ module.exports.ts         = module.exports.js;
 module.exports.peg        = module.exports.js;
 module.exports.pegjs      = module.exports.js;
 module.exports.jade       = module.exports.js;
+module.exports.styl       = module.exports.js;
 
 module.exports.coffee     = module.exports.coffee;
 module.exports.bash       = module.exports.coffee;


### PR DESCRIPTION
This adds the `.styl` [stylus](https://learnboost.github.io/stylus/) file extension to those that are supported by the js regex.