### PR TITLE
Added better Jade support

### DIFF
--- a/lib/regexrules.js
+++ b/lib/regexrules.js
@@ -61,6 +61,38 @@ module.exports = {
       end   : "(?:[ \t]*)?(?://|/\\*)[ \t]*@endfor[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n])?"
     }
   },
+  jade : {
+    echo : [
+      "(?:/\\*)[ \t]*@echo[ \t]*([^\n]*?)[ \t]*(?:\\*(?:\\*|/))",
+      "(?://-)[ \t]*@echo[ \t]*([^\n]*)[ \t]*"
+    ],
+    exec : "(?://-|/\\*)[ \t]*@exec[ \t]*([^\n]*)[ \t]*\\(([^\n]*)\\)[ \t]*(?:\\*(?:\\*|/))?",
+    include : [
+      "(.*)(?:/\\*)[ \t]*@include(?!-)[ \t]*([^\n]*?)[ \t]*(?:\\*(?:\\*|/))",
+      "(.*)(?://-)[ \t]*@include(?!-)[ \t]*([^\n]*)[ \t]*"
+    ],
+    'include-static': [
+      "(.*)(?:/\\*)[ \t]*@include-static[ \t]*([^\n]*?)[ \t]*(?:\\*(?:\\*|/))",
+      "(.*)(?://-)[ \t]*@include-static[ \t]*([^\n]*)[ \t]*"
+    ],
+    exclude : {
+      start : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@exclude[ \t]*([^\n*]*)[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n]+)?",
+      end   : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@endexclude[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n])?"
+    },
+    extend : {
+      start : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@extend(?!able)[ \t]*([^\n*]*)[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n]+)?",
+      end   : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@endextend[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n])?"
+    },
+    extendable : "(?:[ \t]*)(?://-|/\\*)[ \t]*@extendable[ \t]*([^\n*]*)[ \t]*(?:\\*/)?",
+    if : {
+      start : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@(ifndef|ifdef|if)[ \t]*([^\n*]*)[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n]+)?",
+      end   : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@endif[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n])?"
+    },
+    foreach : {
+      start : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@foreach[ \t]*([^\n*]*)[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n]+)?",
+      end   : "(?:[ \t]*)?(?://-|/\\*)[ \t]*@endfor[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*[\n])?"
+    }
+  },
   coffee : {
     echo : "(?:[ \t]*)(?:#+)[ \t]*@echo[ \t]*([^\n]*)[ \t]*",
     exec : "(?:[ \t]*)(?:#+)[ \t]*@exec[ \t]*([^\n]*)[ \t]*\\(([^\n]*)\\)[ \t]*",
@@ -103,7 +135,6 @@ module.exports.php        = module.exports.js;
 module.exports.ts         = module.exports.js;
 module.exports.peg        = module.exports.js;
 module.exports.pegjs      = module.exports.js;
-module.exports.jade       = module.exports.js;
 module.exports.styl       = module.exports.js;
 
 module.exports.coffee     = module.exports.coffee;


### PR DESCRIPTION
Jade has two comment styles:
 //- for comments that are to be stripped before generation to html
// for comments that get converted into <!-- --> in the html.

The //- style comment is important in Jade and it requires the changes to the js regex that I've made.