### PR TITLE
@exec parameters are not parsed correctly

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -187,20 +187,17 @@ function preprocessor(src, context, opts, noRestoreEol) {
   });
 
   rv = replace(rv, opts.type.exec, function (match, name, value) {
+    var reToken = new RegExp(/^\s*(?:("|')(.*?)(?:\1\s*,?|$)|([^,]*?)\s*(?:,|$))/),
+      params = [];
+
+    function token2param(s, q, str, prop) {
+      params.push(typeof str !== 'undefined' ? str : getDeepPropFromObj(context, prop));
+      return '';
+    }
+
     name = (name || '').trim();
-    value = value || '';
-
-    var params = value.split(',');
-    var stringRegex = /^['"](.*)['"]$/;
-
-    params = params.map(function(param){
-      param = param.trim();
-      if (stringRegex.test(param)) { // handle string parameter
-        return param.replace(stringRegex, '$1');
-      } else { // handle variable parameter
-        return getDeepPropFromObj(context, param);
-      }
-    });
+    value = value == null ? ' ' : value + ' '; // space for end of comma
+    while (value.length) { value = value.replace(reToken, token2param); }
 
     var fn = getDeepPropFromObj(context, name);
     if (!fn || typeof fn !== 'function') return '';


### PR DESCRIPTION
The string parameters that include the quotes or commas are not parsed correctly.

For example:

```js
var src = 'foo\n<!-- @exec FNC(' +
  'param1, ' +                            // 0. bare string
  '\'param2\', ' +                        // 1. quoted plain string
  '\'Click "START" button.\', ' +         // 2. double-quotes in single-quotes
  '"Click \'START\' button.", ' +         // 3. single-quotes in double-quotes
  '\'Thu, 09 Jul 2015\', ' +              // 4. comma in quoted string
  '\'Say "1, 2, 3".\', ' +                // 5. comma in quoted string in quoted string
  '\'Click "START", and select one.\'' +  // 6. comma next of quote
  ') -->\nbar';

console.log('==== SRC: ' + src);
console.log('==== RES: ' +
  require('preprocess').preprocess(src, {
    FNC : function() {
      // List all arguments
      return Array.prototype.slice.call(arguments)
        .map(function(arg, i) { return i + ': <' + arg + '>'; }).join('\n');
    },
    param1: 'p1'
  })
);
```

Result:

```console
==== SRC: foo
<!-- @exec FNC(param1, 'param2', 'Click "START" button.', "Click 'START' button.", 'Thu, 09 Jul 2015', 'Say "1, 2, 3".', 'Click "START", and select one.') -->
bar
==== RES: foo
0: <p1>
1: <param2>
2: <Click "START" button.>
3: <Click 'START' button.>
4: <undefined>
5: <undefined>
6: <undefined>
7: <undefined>
8: <undefined>
9: <Click "START>
10: <undefined>
bar
```

0, 1, 2, 3 are OK.
But others are not and number of parameters is incorrect.

Result by fixed code:

```console
==== SRC: foo
<!-- @exec FNC(param1, 'param2', 'Click "START" button.', "Click 'START' button.", 'Thu, 09 Jul 2015', 'Say "1, 2, 3".', 'Click "START", and select one.') -->
bar
==== RES: foo
0: <p1>
1: <param2>
2: <Click "START" button.>
3: <Click 'START' button.>
4: <Thu, 09 Jul 2015>
5: <Say "1, 2, 3".>
6: <Click "START", and select one.>
bar
```

