### PR TITLE
Fix: `getDeepPropFromObj` does not work

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -392,16 +392,21 @@ function copy(obj) {
 }
 
 function getDeepPropFromObj(obj, propPath) {
-  propPath.replace(/\[([^\]+?])\]/g, '.$1');
-  propPath = propPath.split('.');
+  var propPathList = [];
+  propPath = propPath.replace(/(.*?)(?:\[(.+?)\]|\.)/g, function(s, prev, prop) {
+    if (prev) { propPathList.push(prev); }
+    if (prop) { propPathList.push(prop); }
+    return '';
+  });
+  if (propPath) { propPathList.push(propPath); }
 
   // fast path, no need to loop if structurePath contains only a single segment
-  if (propPath.length === 1) {
-    return obj[propPath[0]];
+  if (propPathList.length === 1) {
+    return obj[propPathList[0]];
   }
 
   // loop only as long as possible (no exceptions for null/undefined property access)
-  propPath.some(function (pathSegment) {
+  propPathList.some(function (pathSegment) {
     obj = obj[pathSegment];
     return (obj == null);
   });


### PR DESCRIPTION

A following [code](https://github.com/jsoverson/preprocess/blob/master/lib/preprocess.js#L395) in `getDeepPropFromObj` function in `preprocess.js` doesn't work:

```js
  propPath.replace(/\[([^\]+?])\]/g, '.$1');
```

The `.replace()` method returns a replaced string, and it doesn't change a original string (i.e. propPath). The above code drops a replaced string.
The replaced string must be received:

```js
  propPath = propPath.replace(/\[([^\]+?])\]/g, '.$1');
```

---

A current code doesn't catch the properties that is named 2 or more length when `VAR[PROP]` style is specified.
For example:

```js
var src =
  'VAR.A: <!-- @echo VAR.A -->\n' +
  'VAR.B: <!-- @echo VAR.B -->\n' +
  'VAR.AA: <!-- @echo VAR.AA -->\n' +
  'VAR.BB: <!-- @echo VAR.BB -->\n' +
  'VAR[A]: <!-- @echo VAR[A] -->\n' +
  'VAR[B]: <!-- @echo VAR[B] -->\n' +
  'VAR[AA]: <!-- @echo VAR[AA] -->\n' +
  'VAR[BB]: <!-- @echo VAR[BB] -->\n'
  ;

console.log(
  require('preprocess').preprocess(src, {
    VAR: {
      A: 'var.a',
      B: 'var.b',
      AA: 'var.aa',
      BB: 'var.bb'
    }
  })
);
```

Result:

```console
VAR.A: var.a
VAR.B: var.b
VAR.AA: var.aa
VAR.BB: var.bb
VAR[A]: var.a
VAR[B]: var.b
VAR[AA]: undefined
VAR[BB]: undefined
```

A regexp in current code:

```js
/\[([^\]+?])\]/g
```

This matches one character, except `]`, `+`, and `?`.
I think that `+?` should have been a pattern not literal:

```js
/\[([^\]]+?)\]/g
```

And, `[^\]]` is unnecessary because `?` works:

```js
/\[(.+?)\]/g
```

Result by the above:

```console
VAR.A: var.a
VAR.B: var.b
VAR.AA: var.aa
VAR.BB: var.bb
VAR[A]: var.a
VAR[B]: var.b
VAR[AA]: var.aa
VAR[BB]: var.bb
```

---

A current code doesn't discern a property name via `VAR.PROP` and `VAR[PROP]`, and it splits also a property name of `VAR[PROP]`.
For example:

```js
var src =
  'VAR.A.B: <!-- @echo VAR.A.B -->\n' +
  'VAR[A.B]: <!-- @echo VAR[A.B] -->\n'
  ;

console.log(
  require('preprocess').preprocess(src, {
    VAR: {
      A: {B: 'var.a.b'},
      'A.B' : 'var[a.b]'
    }
  })
);
```

Result:

```console
VAR.A.B: var.a.b
VAR[A.B]: var.a.b
```

This PR discerns those.
Result by fixed code:

```console
VAR.A.B: var.a.b
VAR[A.B]: var[a.b]
```

This fixed code discerns also a name like `VAR[AA].B[CC.DD][E]` correctly.
