### PR TITLE
Fix: End of JavaScript comments are not parsed

### DIFF
--- a/lib/regexrules.js
+++ b/lib/regexrules.js
@@ -1,87 +1,145 @@
 
+var
+  SP = '[ \\t]',
+  NL_OPTIONAL = '(?:' + SP + '*\\n)?',
+  NLS_OPTIONAL = '(?:' + SP + '*\\n+)?',
+  IND = '^(.*?)', // indent (all cols from 0 col)
+
+  ARGS = SP + '+(.+?)', // require separator(SPs)
+  ARGS_OPTIONAL = '(?:' + ARGS + ')?',
+  FUNC = ARGS + SP + '*\\((.*)\\)', // Not `\\((.*?)\\)`
+
+  // ======================== html
+  START_HTML = '<!--' + SP + '*', // include inside SPs
+  SP_START_HTML = SP + '*' + START_HTML,
+  IND_START_HTML = IND + START_HTML,
+  END_HTML = SP + '*(?:-->|!>)',
+  END_HTML_NL = END_HTML + NL_OPTIONAL,
+  END_HTML_NLS = END_HTML + NLS_OPTIONAL,
+
+  // ======================== js
+  _START_JS1 = '//',
+  _START_JS2 = '/\\*',
+  START_JS1 = _START_JS1 + SP + '*', // include inside SPs
+  START_JS2 = _START_JS2 + SP + '*', // include inside SPs
+  START_JS = '(?:' + _START_JS1 + '|' + _START_JS2 + ')' + SP + '*', // include inside SPs
+  SP_START_JS = SP + '*' + START_JS,
+  IND_START_JS1 = IND + START_JS1,
+  IND_START_JS2 = IND + START_JS2,
+  END_JS_LINE = SP + '*(?:\\*\\*|\\*/|$)',
+  _END_JS = '(?:\\*\\*|\\*/)',
+  END_JS = SP + '*' + _END_JS,
+  END_JS_NL = SP + '*(?:' + _END_JS + NL_OPTIONAL + '|(?:\\n|$))',
+  END_JS_NLS = SP + '*(?:' + _END_JS + NLS_OPTIONAL + '|(?:\\n+|$))',
+
+  // ======================== coffee
+  START_COFFEE = '#+' + SP + '*', // include inside SPs
+  SP_START_COFFEE = SP + '*' + START_COFFEE,
+  IND_START_COFFEE = IND + START_COFFEE,
+  END_COFFEE_LINE = SP + '*$',
+  END_COFFEE_NL = SP + '*(?:\\n|$)',
+  END_COFFEE_NLS = SP + '*(?:\\n+|$)',
+
+  // ======================== directives
+  DIR_ECHO =              '@echo' + ARGS,
+  DIR_EXEC =              '@exec' + FUNC,
+  DIR_INCLUDE =           '@include(?!-)' + ARGS,
+  DIR_INCLUDE_STATIC =    '@include-static' + ARGS,
+  DIR_EXCLUDE_START =     '@exclude' + ARGS_OPTIONAL,
+  DIR_EXCLUDE_END =       '@endexclude',
+  DIR_EXTEND_START =      '@extend(?!able)' + ARGS,
+  DIR_EXTEND_END =        '@endextend',
+  DIR_EXTENDABLE =        '@extendable',
+  DIR_IF_START =          '@(ifndef|ifdef|if)' + ARGS,
+  DIR_IF_END =            '@endif',
+  DIR_FOREACH_START =     '@foreach' + ARGS,
+  DIR_FOREACH_END =       '@endfor'
+  ;
+
 module.exports = {
   simple : {
-    echo : "^@echo[ \t]+(.*?)[ \t]*$",
-    exec : "^@exec[ \t]+(\\S+)[ \t]*\\((.*)\\)[ \t]*$",
-    include          : "^(.*)@include(?!-)[ \t]+(.*?)[ \t]*$", // allow prefix characters to specify the indent level of included file
-    'include-static' : "^(.*)@include-static[ \t]+(.*?)[ \t]*$"
+    echo :              '^' +                   DIR_ECHO +              '[ \t]*$',
+    exec :              '^' +                   DIR_EXEC +              '[ \t]*$',
+    include :           IND +                   DIR_INCLUDE +           '[ \t]*$',
+          // allow prefix characters to specify the indent level of included file
+    'include-static' :  IND +                   DIR_INCLUDE_STATIC +    '[ \t]*$'
   },
   html : {
-    echo : "<!--[ \t]*@echo[ \t]+(.*?)[ \t]*(?:-->|!>)",
-    exec : "<!--[ \t]*@exec[ \t]+(\\S+)[ \t]*\\((.*)\\)[ \t]*(?:-->|!>)",
-    include          : "(.*)<!--[ \t]*@include(?!-)[ \t]+(.*?)[ \t]*(?:-->|!>)",
-    'include-static' : "(.*)<!--[ \t]*@include-static[ \t]+(.*?)[ \t]*(?:-->|!>)",
+    echo :              START_HTML +            DIR_ECHO +              END_HTML,
+    exec :              START_HTML +            DIR_EXEC +              END_HTML,
+    include :           IND_START_HTML +        DIR_INCLUDE +           END_HTML,
+    'include-static' :  IND_START_HTML +        DIR_INCLUDE_STATIC +    END_HTML,
     exclude : {
-      start : "[ \t]*<!--[ \t]*@exclude(?:[ \t]+(.*?))?[ \t]*(?:-->|!>)(?:[ \t]*\n+)?",
-      end   : "[ \t]*<!--[ \t]*@endexclude[ \t]*(?:-->|!>)(?:[ \t]*\n)?"
+      start :           SP_START_HTML +         DIR_EXCLUDE_START +     END_HTML_NLS,
+      end   :           SP_START_HTML +         DIR_EXCLUDE_END +       END_HTML_NL
     },
     extend : {
-      start : "[ \t]*<!--[ \t]*@extend(?!able)[ \t]+(.*?)[ \t]*(?:-->|!>)(?:[ \t]*\n+)?",
-      end   : "[ \t]*<!--[ \t]*@endextend[ \t]*(?:-->|!>)(?:[ \t]*\n)?"
+      start :           SP_START_HTML +         DIR_EXTEND_START +      END_HTML_NLS,
+      end   :           SP_START_HTML +         DIR_EXTEND_END +        END_HTML_NL
     },
-    extendable : "<!--[ \t]*@extendable[ \t]*(?:-->|!>)",
+    extendable :        SP_START_HTML +         DIR_EXTENDABLE +        END_HTML,
     if : {
-      start : "[ \t]*<!--[ \t]*@(ifndef|ifdef|if)[ \t]+(.*?)[ \t]*(?:-->|!>)(?:[ \t]*\n+)?",
-      end   : "[ \t]*<!(?:--)?[ \t]*@endif[ \t]*(?:-->|!>)(?:[ \t]*\n)?"
+      start :           SP_START_HTML +         DIR_IF_START +          END_HTML_NLS,
+      end   :           SP_START_HTML +         DIR_IF_END +            END_HTML_NL
     },
     foreach : {
-      start : "[ \t]*<!--[ \t]*@foreach[ \t]+(.*?)[ \t]*(?:-->|!>)(?:[ \t]*\n+)?",
-      end   : "[ \t]*<!(?:--)?[ \t]*@endfor[ \t]*(?:-->|!>)(?:[ \t]*\n)?"
+      start :           SP_START_HTML +         DIR_FOREACH_START +     END_HTML_NLS,
+      end   :           SP_START_HTML +         DIR_FOREACH_END +       END_HTML_NL
     }
   },
   js : {
     echo : [
-      "/\\*[ \t]*@echo[ \t]+(.*?)[ \t]*\\*(?:\\*|/)",
-      "//[ \t]*@echo[ \t]+(.*?)[ \t]*$"
+                        START_JS1 +             DIR_ECHO +              END_JS_LINE,
+                        START_JS2 +             DIR_ECHO +              END_JS_LINE
     ],
-    exec : "(?://|/\\*)[ \t]*@exec[ \t]+(\\S+)[ \t]*\\((.*)\\)[ \t]*(?:\\*(?:\\*|/))?",
+    exec :              START_JS +              DIR_EXEC +              END_JS_LINE,
     include : [
-      "^(.*)/\\*[ \t]*@include(?!-)[ \t]+(.*?)[ \t]*\\*(?:\\*|/)",
-      "^(.*)//[ \t]*@include(?!-)[ \t]+(.*?)[ \t]*$"
+                        IND_START_JS1 +         DIR_INCLUDE +           END_JS_LINE,
+                        IND_START_JS2 +         DIR_INCLUDE +           END_JS_LINE
     ],
-    'include-static': [
-      "^(.*)/\\*[ \t]*@include-static[ \t]+(.*?)[ \t]*\\*(?:\\*|/)",
-      "^(.*)//[ \t]*@include-static[ \t]+(.*?)[ \t]*$"
+    'include-static' : [
+                        IND_START_JS1 +         DIR_INCLUDE_STATIC +    END_JS_LINE,
+                        IND_START_JS2 +         DIR_INCLUDE_STATIC +    END_JS_LINE
     ],
     exclude : {
-      start : "[ \t]*(?://|/\\*)[ \t]*@exclude(?:[ \t]+([^\n*]*))?[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*\n+)?",
-      end   : "[ \t]*(?://|/\\*)[ \t]*@endexclude[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*\n)?"
+      start :           SP_START_JS +           DIR_EXCLUDE_START +     END_JS_NLS,
+      end   :           SP_START_JS +           DIR_EXCLUDE_END +       END_JS_NL
     },
     extend : {
-      start : "[ \t]*(?://|/\\*)[ \t]*@extend(?!able)[ \t]+([^\n*]*)(?:\\*(?:\\*|/))?(?:[ \t]*\n+)?",
-      end   : "[ \t]*(?://|/\\*)[ \t]*@endextend[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*\n)?"
+      start :           SP_START_JS +           DIR_EXTEND_START +      END_JS_NLS,
+      end   :           SP_START_JS +           DIR_EXTEND_END +        END_JS_NL
     },
-    extendable : "[ \t]*(?://|/\\*)[ \t]*@extendable[ \t]*(?:\\*/)?",
+    extendable :        SP_START_JS +           DIR_EXTENDABLE +        END_JS_LINE,
     if : {
-      start : "[ \t]*(?://|/\\*)[ \t]*@(ifndef|ifdef|if)[ \t]+([^\n*]*)(?:\\*(?:\\*|/))?(?:[ \t]*\n+)?",
-      end   : "[ \t]*(?://|/\\*)[ \t]*@endif[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*\n)?"
+      start :           SP_START_JS +           DIR_IF_START +          END_JS_NLS,
+      end   :           SP_START_JS +           DIR_IF_END +            END_JS_NL
     },
     foreach : {
-      start : "[ \t]*(?://|/\\*)[ \t]*@foreach[ \t]+([^\n*]*)(?:\\*(?:\\*|/))?(?:[ \t]*\n+)?",
-      end   : "[ \t]*(?://|/\\*)[ \t]*@endfor[ \t]*(?:\\*(?:\\*|/))?(?:[ \t]*\n)?"
+      start :           SP_START_JS +           DIR_FOREACH_START +     END_JS_NLS,
+      end   :           SP_START_JS +           DIR_FOREACH_END +       END_JS_NL
     }
   },
   coffee : {
-    echo : "#+[ \t]*@echo[ \t]+(.*?)[ \t]*$",
-    exec : "#+[ \t]*@exec[ \t]+(\\S+)[ \t]*\\((.*)\\)[ \t]*$",
-    include          : "^(.*?)#+[ \t]*@include(?!-)[ \t]+(.*?)[ \t]*$",
-    'include-static' : "^(.*?)#+[ \t]*@include-static[ \t]+(.*?)[ \t]*$",
+    echo :              START_COFFEE +          DIR_ECHO +              END_COFFEE_LINE,
+    exec :              START_COFFEE +          DIR_EXEC +              END_COFFEE_LINE,
+    include :           IND_START_COFFEE +      DIR_INCLUDE +           END_COFFEE_LINE,
+    'include-static' :  IND_START_COFFEE +      DIR_INCLUDE_STATIC +    END_COFFEE_LINE,
     exclude : {
-      start : "^[ \t]*#+[ \t]*@exclude(?:[ \t]+(.*?))?[ \t]*\n+",
-      end   : "^[ \t]*#+[ \t]*@endexclude[ \t]*\n?"
+      start :           SP_START_COFFEE +       DIR_EXCLUDE_START +     END_COFFEE_NLS,
+      end   :           SP_START_COFFEE +       DIR_EXCLUDE_END +       END_COFFEE_NL
     },
     extend : {
-      start : "^[ \t]*#+[ \t]*@extend(?!able)[ \t]+(.*?)\n+",
-      end   : "^[ \t]*#+[ \t]*@endextend[ \t]*\n?"
+      start :           SP_START_COFFEE +       DIR_EXTEND_START +      END_COFFEE_NLS,
+      end   :           SP_START_COFFEE +       DIR_EXTEND_END +        END_COFFEE_NL
     },
-    extendable : "^[ \t]*#+[ \t]*@extendable[ \t]*$",
+    extendable :        SP_START_COFFEE +       DIR_EXTENDABLE +        END_COFFEE_LINE,
     if : {
-      start : "^[ \t]*#+[ \t]*@(ifndef|ifdef|if)[ \t]+(.*?)[ \t]*\n+",
-      end   : "^[ \t]*#+[ \t]*@endif[ \t]*\n?"
+      start :           SP_START_COFFEE +       DIR_IF_START +          END_COFFEE_NLS,
+      end   :           SP_START_COFFEE +       DIR_IF_END +            END_COFFEE_NL
     },
     foreach : {
-      start : "^[ \t]*#+[ \t]*@foreach[ \t]+(.*?)[ \t]*\n+",
-      end   : "^[ \t]*#+[ \t]*@endfor[ \t]*\n?"
+      start :           SP_START_COFFEE +       DIR_FOREACH_START +     END_COFFEE_NLS,
+      end   :           SP_START_COFFEE +       DIR_FOREACH_END +       END_COFFEE_NL
     }
   }
 };


### PR DESCRIPTION
Issue:
https://github.com/jsoverson/preprocess/issues/77#issuecomment-120682188

In JavaScript code, that regexp stops reading immediately it found `*` without checking `*/` or end of line, etc..
Because that regexp accepts these as the end of the directive:

1. `**`
2. `*/`
3. Nothing

That regexp accepts "Nothing". And `*` as the parameters is not accepted.

For example:

```js
console.log(
  require('preprocess').preprocess(
    'foo/* @if SIZE * 1024 > MEM */ BIG/* @endif */ bar',
    {SIZE: 2, MEM: 1024},
    {type: 'js'}
  )
);
```

Result:

```console
foo* 1024 > MEM */ BIG bar
```

This PR fixes this bug, and puts common patterns into the variables.
