### PR TITLE
Option to use source file extension as default for import/extend

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -59,6 +59,7 @@ function preprocess(src, context, typeOrOptions) {
   // default values
   var options = {
     fileNotFoundSilentFail: false,
+    defaultSourceExtension: false,
     srcDir: process.cwd(),
     srcEol: getEolType(src),
     type: delim['html']
@@ -80,12 +81,12 @@ function preprocess(src, context, typeOrOptions) {
   if (typeOrOptions && typeof typeOrOptions === 'object') {
     options.srcDir = typeOrOptions.srcDir || options.srcDir;
     options.fileNotFoundSilentFail = typeOrOptions.fileNotFoundSilentFail || options.fileNotFoundSilentFail;
+    options.defaultSourceExtension = typeOrOptions.defaultSourceExtension || options.defaultSourceExtension;
     options.srcEol = typeOrOptions.srcEol || options.srcEol;
     options.type = delim[typeOrOptions.type] || options.type;
   }
 
   context = copy(context);
-
   return preprocessor(src, context, options);
 }
 
@@ -101,6 +102,9 @@ function preprocessor(src, context, opts, noRestoreEol) {
       var file = (startMatches[1] || '').trim();
       var extendedContext = copy(context);
       var extendedOpts = copy(opts);
+      if (file.indexOf('.') < 0 && opts.defaultSourceExtension && extendedContext.src) {
+        file += '.'+getExtension(extendedContext.src);
+      }
       extendedContext.src = path.join(opts.srcDir, file);
       extendedOpts.srcDir = path.dirname(extendedContext.src);
 
@@ -328,9 +332,12 @@ function processIncludeDirective(isStatic, context, opts, match, linePrefix, fil
   var indent = linePrefix.replace(/\S/g, ' ');
   var includedContext = copy(context);
   var includedOpts = copy(opts);
+  if (file.indexOf('.') < 0 && opts.defaultSourceExtension && context.src) {
+    file += '.'+getExtension(context.src);
+  }
+
   includedContext.src = path.join(opts.srcDir,file);
   includedOpts.srcDir = path.dirname(includedContext.src);
-
   var fileContents = getFileContents(includedContext.src, opts.fileNotFoundSilentFail, context.src);
   if (fileContents.error) {
     return linePrefix + fileContents.contents;


### PR DESCRIPTION
Here's an idea for an option, to be able to abbreviate file extensions in import/extend statements.

The following would include `partial.html`

```html
<!-- @include partial -->
```

When the option `defaultSourceExtension` is true, import/extend without file extension will use the source file's extension by default. Inside an HTML file, it will add `.html`, and so on.