### PR TITLE
adds javascript object output to fix [object Object] #48

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -182,8 +182,9 @@ function preprocessor(src, context, opts, noRestoreEol) {
     // if we are surrounded by quotes, echo as a string
     var stringMatch = variable.match(/^(['"])(.*)\1$/);
     if (stringMatch) return stringMatch[2];
-
-    return getDeepPropFromObj(context, (variable || '').trim());
+    var value = getDeepPropFromObj(context, (variable || '').trim());
+    if (typeof value === "object") return JSON.stringify(value);
+    return value;
   });
 
   rv = replace(rv, opts.type.exec, function (match, name, value) {
@@ -275,7 +276,7 @@ function replace(rv, rule, processor) {
   }
 
   return rule.reduce(function(rv, rule){
-    return rv.replace(rule, processor);
+    return rv.replace(rule, processor );
   }, rv);
 }
 
@@ -404,6 +405,7 @@ function getDeepPropFromObj(obj, propPath) {
     obj = obj[pathSegment];
     return (obj == null);
   });
+
 
   return obj;
 }


### PR DESCRIPTION
- [ x] 99.9% of tests passing
- [ ] Check with @jsoverson why do this lib expects the object to be printed as [object Object] on "and maintain backwards compatibility"
