### PR TITLE
getTestTemplate causing Expected () to start arrow function, but got ';' instead of '=>' ` warning

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -353,7 +353,7 @@ function processIncludeDirective(isStatic, context, opts, match, linePrefix, fil
 
 function getTestTemplate(test) {
   /*jshint evil:true*/
-  test = test || 'true';
+  test = typeof test === 'undefined' || test === "" || test === null || /\s+/.test(test) ? "true" : test;
   test = test.trim();
 
   // force single equals replacement


### PR DESCRIPTION
Modified the getTestTemplate function. The check for `test` availability wasn't accurate enough. `var || 'default'` does not cover a lot of episodes. Infact I was getting an `Expected () to start arrow function, but got ';' instead of '=>' ` warning because `test` was a series of blank spaces so it wasn't undefined so it wasn't been converted in `true` and the trim would transform it in an empty string. Lately `return ();` threw the warning.