### PR TITLE
Support for option.alias for define file load path.

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -61,7 +61,8 @@ function preprocess(src, context, typeOrOptions) {
     fileNotFoundSilentFail: false,
     srcDir: process.cwd(),
     srcEol: getEolType(src),
-    type: delim['html']
+    type: delim['html'],
+    alias: {}
   };
 
   // needed for backward compatibility with 2.x.x series
@@ -82,6 +83,7 @@ function preprocess(src, context, typeOrOptions) {
     options.fileNotFoundSilentFail = typeOrOptions.fileNotFoundSilentFail || options.fileNotFoundSilentFail;
     options.srcEol = typeOrOptions.srcEol || options.srcEol;
     options.type = delim[typeOrOptions.type] || options.type;
+    options.alias = typeOrOptions.alias || options.alias;
   }
 
   context = copy(context);
@@ -327,7 +329,24 @@ function processIncludeDirective(isStatic, context, opts, match, linePrefix, fil
   var indent = linePrefix.replace(/\S/g, ' ');
   var includedContext = copy(context);
   var includedOpts = copy(opts);
-  includedContext.src = path.join(opts.srcDir,file);
+
+  var aliasKeys = Object.keys(opts.alias);
+  for (var i = 0; i < aliasKeys.length; i++) {
+    var aliasKey = aliasKeys[i];
+    var aliasKeyReg = new RegExp(aliasKey);
+    var aliasVal = opts.alias[aliasKey];
+
+    if (file.match(aliasKeyReg)) {
+      file = file.replace(aliasKeyReg, aliasVal);
+      break;
+    }
+  }
+
+  if (file[0] === '/' || file[0] === '\\') {
+    includedContext.src = file;
+  } else {
+    includedContext.src = path.join(opts.srcDir,file);
+  }
   includedOpts.srcDir = path.dirname(includedContext.src);
 
   var fileContents = getFileContents(includedContext.src, opts.fileNotFoundSilentFail, context.src);

--- a/test/options.spec.js
+++ b/test/options.spec.js
@@ -64,4 +64,11 @@ describe('shall support multiple call signatures', function () {
       pp.preprocess(input, {}, {srcEol: '\r\n', srcDir: 'test/fixtures/include'}).should.equal("a\r\n!bazqux!\r\nc");
     });
   });
+
+  describe('and support alias(dir path) options', function () {
+    it('and use alias option', function () {
+      input = "a<!--@include @static.txt-->c";
+      pp.preprocess(input, {}, { alias: { '@': 'test/fixtures/include/' } }).should.equal("a!bazqux!c");
+    });
+  });
 });

--- a/test/options.spec.js
+++ b/test/options.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var chai = require('chai'),
+var path = require('path'),
+  chai = require('chai'),
   pp = require('../lib/preprocess');
 
 chai.should();
@@ -66,9 +67,13 @@ describe('shall support multiple call signatures', function () {
   });
 
   describe('and support alias(dir path) options', function () {
-    it('and use alias option', function () {
+    it('and use alias option with relative path', function () {
       input = "a<!--@include @static.txt-->c";
       pp.preprocess(input, {}, { alias: { '@': 'test/fixtures/include/' } }).should.equal("a!bazqux!c");
+    });
+    it('and use alias option with absolute path', function () {
+      input = "a<!--@include @static.txt-->c";
+      pp.preprocess(input, {}, { alias: { '@': path.join(__dirname, 'fixtures/include/') } }).should.equal("a!bazqux!c");
     });
   });
 });


### PR DESCRIPTION
## Usage

```js
// a<!--@include @static.txt-->c
preprocess.preprocess(input, {}, { alias: { '@': 'test/fixtures/include/' } })
pp.preprocess(input, {}, { alias: { '@': path.join(__dirname, 'fixtures/include/') } }).should.equal("a!bazqux!c");
```
## Node

Alias value must be a dir path.

## Test

Coverage summary before [704d2898](https://github.com/jsoverson/preprocess/commit/704d28987837f38abcd6b2e07ba65928e43f2983)

Statements   : 96.8% ( 242/250 )
Branches     : 86.15% ( 112/130 )
Functions    : 100% ( 33/33 )
Lines        : 97.57% ( 241/247 )

Coverage summary after

Statements   : 96.93% ( 253/261 )
Branches     : 86.23% ( 119/138 )
Functions    : 100% ( 33/33 )
Lines        : 97.67% ( 252/258 )

