### PR TITLE
Update npm dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,7 @@ language: node_js
 node_js:
   - node
   - lts/*
-  - "10"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - 10
 install:
   - npm install
 script: "npm run-script ci"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('coverage', ['clean:coverage', 'mocha_istanbul:coverage']);
   grunt.registerTask('test', ['jshint', 'mochaTest:preprocess']);
-  grunt.registerTask('dev', ['deps-ok', 'watch']);
   grunt.registerTask('default', ['test', 'coverage']);
   grunt.registerTask('ci', ['default', 'coveralls']);
 };

--- a/package.json
+++ b/package.json
@@ -30,26 +30,26 @@
     "ci": "grunt ci"
   },
   "dependencies": {
-    "xregexp": "3.1.0"
+    "xregexp": "^4.3.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-spies": "^0.7.0",
-    "grunt": "^0.4.5",
-    "grunt-benchmark": "^0.3.0",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-coveralls": "^1.0.0",
+    "chai": "^4.2.0",
+    "chai-spies": "^1.0.0",
+    "grunt": "^1.1.0",
+    "grunt-benchmark": "^1.0.0",
+    "grunt-cli": "^1.3.2",
+    "grunt-contrib-clean": "^2.0.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-coveralls": "^2.0.0",
     "grunt-deps-ok": "^0.9.0",
-    "grunt-mocha-istanbul": "^3.0.1",
-    "grunt-mocha-test": "^0.12.7",
+    "grunt-mocha-istanbul": "^5.0.2",
+    "grunt-mocha-test": "^0.13.3",
     "istanbul": "^0.4.2",
-    "load-grunt-tasks": "^3.4.0",
-    "mocha": "^2.4.5",
-    "time-grunt": "^1.3.0",
+    "load-grunt-tasks": "^5.1.0",
+    "mocha": "7.1.2",
+    "time-grunt": "^2.0.0",
     "travis-cov": "^0.2.5"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "lib/preprocess.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=10"
   },
   "scripts": {
     "test": "grunt test",
@@ -43,7 +43,6 @@
     "grunt-contrib-jshint": "^2.1.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-coveralls": "^2.0.0",
-    "grunt-deps-ok": "^0.9.0",
     "grunt-mocha-istanbul": "^5.0.2",
     "grunt-mocha-test": "^0.13.3",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
Considering the PR that has been merged lately, we probably need to a bump a major version. Taking this opportunity to also drop support of old Node versions.

- Update all dependencies
- Drop support of Node < 10 ⚠️
- Remove `grunt-deps-ok`, removing all `npm audit` vulnerabilities. npm is pretty reliable nowadays. We can commit the `package-lock.json` if we have issues one day. Plus, it doesn't really make sense IMHO to verify dependencies by adding even more dependencies 💦 